### PR TITLE
Added new dns zone methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ A complete PHP SDK for interacting with the Hostinger API, allowing you to progr
       * [Get Snapshot List](#get-snapshot-list)
     * [Zone](#zone)
       * [Get Records](#get-records)
+      * [Update Zone Records](#update-zone-records)
+      * [Delete Zone Records](#delete-zone-records)
+      * [Validate Zone Records](#validate-zone-records)
       * [Reset Zone Records](#reset-zone-records)
   * [Billing](#billing)
     * [Catalog](#catalog)
@@ -279,6 +282,80 @@ foreach ($recordGroups as $group) {
 }
 ```
 
+#### Update Zone Records
+
+Updates DNS records for the selected domain. Using overwrite = true (default) replaces records; otherwise, appends or updates TTLs.
+
+```php
+$domainName = "mydomain.tld";
+$data = [
+    'overwrite' => true, // Optional
+    'zone' => [
+        [
+            'name' => 'www',
+            'records' => [['content' => '192.0.2.1']],
+            'ttl' => 3600, // Optional
+            'type' => 'A',
+        ],
+        [
+            'name' => 'www',
+            'records' => [['content' => 'example.com.']],
+            'type' => 'CNAME',
+        ],
+    ],
+];
+
+$response = $hostinger->dns()->zones()->update($domainName, $data);
+
+$response->message; // Request accepted
+$response->toArray(); // ['message' => 'Request accepted']
+```
+
+#### Delete Zone Records
+
+Deletes specific DNS records based on name and type filters.
+
+```php
+$domainName = "mydomain.tld";
+$data = [
+    'filters' => [
+        ['name' => '@', 'type' => 'A']
+    ],
+];
+
+$response = $hostinger->dns()->zones()->delete($domainName, $data);
+
+$response->message; // Request accepted
+$response->toArray(); // ['message' => 'Request accepted']
+```
+
+#### Validate Zone Records
+
+Validates DNS records before attempting an update. Throws a ValidationException if invalid.
+
+```php
+$domainName = "mydomain.tld";
+$data = [
+    'zone' => [
+        [
+            'name' => 'valid',
+            'records' => [['content' => '192.0.2.10']],
+            'type' => 'A',
+        ]
+    ],
+];
+
+try {
+    $response = $hostinger->dns()->zones()->validate($domainName, $data);
+    $response->message;
+    $response->toArray(); // ['message' => '...']
+} catch (\DerrickOb\HostingerApi\Exceptions\ValidationException $e) {
+    // Handle validation failure
+    echo "Validation failed: " . $e->getMessage();
+    print_r($e->getErrors());
+}
+```
+
 #### Reset Zone Records
 
 Resets the DNS zone for a domain to the default Hostinger records.
@@ -479,7 +556,6 @@ foreach ($subscriptions as $subscription) {
     $subscription->created_at->format('Y-m-d H:i:s'); // 2025-02-27 11:54:22
     $subscription->expires_at->format('Y-m-d H:i:s'); // 2025-03-27 11:54:22
     $subscription->next_billing_at ? $subscription->next_billing_at->format('Y-m-d H:i:s') : null; // 2025-02-28 11:54:22
-    $subscription->canceled_at ? $subscription->canceled_at->format('Y-m-d H:i:s') : null; // 2025-02-28 11:54:22
 
     $subscription->toArray(); // ['id' => '...', 'name' => 'KVM 1', 'status' => 'active', 'auto_renew' => true, ...]
 }

--- a/README.md
+++ b/README.md
@@ -219,10 +219,19 @@ $snapshot = $hostinger->dns()->snapshots()->get($domainName, $snapshotId);
 
 $snapshot->id; // 53513053
 $snapshot->reason; // Zone records update request
-$snapshot->snapshot; // {}
 $snapshot->created_at->format('Y-m-d H:i:s'); // 2025-02-27 11:54:22
 
-$snapshot->toArray(); // ['id' => 53513053, 'reason' => '...', 'snapshot' => '{}', 'created_at' => ...]
+foreach ($snapshot->snapshot as $recordGroup) {
+    $recordGroup->name; // www
+    $recordGroup->type; // A
+    $recordGroup->ttl; // 14400
+    foreach ($recordGroup->records as $recordValue) {
+         $recordValue->content; // mydomain.tld.
+         $recordValue->disabled; // false
+    }
+}
+
+$snapshot->toArray(); // ['id' => 53513053, 'reason' => '...', 'snapshot' => [[...], ...], 'created_at' => ...]
 ```
 
 #### Restore Snapshot

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,15 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.9",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-curl": "*"
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
         "friendsofphp/php-cs-fixer": "^3.75",
         "mockery/mockery": "^1.6",
         "pestphp/pest": "^3.8",
+        "php-coveralls/php-coveralls": "^0.1.0",
         "phpstan/phpstan": "^2.1",
         "rector/rector": "^2.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,7 @@ parameters:
     ignoreErrors:
         - '#Function faker not found#'
         - '#Function createMockClient not found#'
+        - '#Function createMockHttpClient not found#'
         - '#Access to an undefined property DerrickOb\\HostingerApi\\Data\\Data::\$.*#'
         - '#Unable to resolve the template type TAndValue in call to method Pest\\Expectation<mixed>::and\(\)#'
         - '#Unable to resolve the template type TAndValue in call to method Pest\\Expectation<.*>::and\(\)#'

--- a/src/Data/Billing/Subscription.php
+++ b/src/Data/Billing/Subscription.php
@@ -45,14 +45,11 @@ final class Subscription extends Data
     /** @var DateTimeImmutable Date and time when the subscription was created. */
     public DateTimeImmutable $created_at;
 
-    /** @var DateTimeImmutable Date and time when the subscription expires. */
-    public DateTimeImmutable $expires_at;
+    /** @var DateTimeImmutable|null Date and time when the subscription expires. */
+    public ?DateTimeImmutable $expires_at;
 
     /** @var DateTimeImmutable|null Date and time of the next billing. */
     public ?DateTimeImmutable $next_billing_at;
-
-    /** @var DateTimeImmutable|null Date and time when the subscription was canceled, if applicable. */
-    public ?DateTimeImmutable $canceled_at;
 
     /**
      * @param array{
@@ -66,9 +63,8 @@ final class Subscription extends Data
      *      renewal_price: int,
      *      auto_renew: bool,
      *      created_at: string,
-     *      expires_at: string,
-     *      next_billing_at?: string,
-     *      canceled_at?: string
+     *      expires_at?: string|null,
+     *      next_billing_at?: string|null
      *  } $data
      *
      * @throws Exception
@@ -85,8 +81,7 @@ final class Subscription extends Data
         $this->renewal_price = $data['renewal_price'];
         $this->auto_renew = $data['auto_renew'];
         $this->created_at = new DateTimeImmutable($data['created_at']);
-        $this->expires_at = new DateTimeImmutable($data['expires_at']);
+        $this->expires_at = isset($data['expires_at']) ? new DateTimeImmutable($data['expires_at']) : null;
         $this->next_billing_at = isset($data['next_billing_at']) ? new DateTimeImmutable($data['next_billing_at']) : null;
-        $this->canceled_at = isset($data['canceled_at']) ? new DateTimeImmutable($data['canceled_at']) : null;
     }
 }

--- a/src/Data/Dns/SnapshotWithContent.php
+++ b/src/Data/Dns/SnapshotWithContent.php
@@ -19,8 +19,8 @@ final class SnapshotWithContent extends Data
     /** @var string Reason for the snapshot creation. */
     public string $reason;
 
-    /** @var string Contents of the DNS zone. */
-    public string $snapshot;
+    /** @var array<Name> Contents of the DNS zone records at the time of the snapshot. */
+    public array $snapshot;
 
     /** @var DateTimeImmutable Date and time when the snapshot was created. */
     public DateTimeImmutable $created_at;
@@ -29,7 +29,15 @@ final class SnapshotWithContent extends Data
      * @param array{
      *      id: int,
      *      reason: string,
-     *      snapshot: string,
+     *      snapshot: array<array{
+     *          name: string,
+     *          records: array<array{
+     *              content: string,
+     *              disabled?: bool
+     *          }>,
+     *          ttl: int,
+     *          type: string
+     *      }>,
      *      created_at: string
      *  } $data
      *
@@ -39,7 +47,10 @@ final class SnapshotWithContent extends Data
     {
         $this->id = $data['id'];
         $this->reason = $data['reason'];
-        $this->snapshot = $data['snapshot'];
+        $this->snapshot = array_map(
+            fn (array $record): Name => new Name($record),
+            $data['snapshot']
+        );
         $this->created_at = new DateTimeImmutable($data['created_at']);
     }
 }

--- a/src/Data/PaginatedResponse.php
+++ b/src/Data/PaginatedResponse.php
@@ -77,7 +77,7 @@ final class PaginatedResponse implements \JsonSerializable
      */
     public function getCurrentPage(): int
     {
-        return $this->meta['current_page'] ?? 1;
+        return $this->meta['current_page'];
     }
 
     /**
@@ -87,7 +87,7 @@ final class PaginatedResponse implements \JsonSerializable
      */
     public function getPerPage(): int
     {
-        return $this->meta['per_page'] ?? count($this->data);
+        return $this->meta['per_page'];
     }
 
     /**
@@ -97,7 +97,7 @@ final class PaginatedResponse implements \JsonSerializable
      */
     public function getTotal(): int
     {
-        return $this->meta['total'] ?? count($this->data);
+        return $this->meta['total'];
     }
 
     /**

--- a/src/Enums/VirtualMachineState.php
+++ b/src/Enums/VirtualMachineState.php
@@ -7,7 +7,19 @@ namespace DerrickOb\HostingerApi\Enums;
 enum VirtualMachineState: string
 {
     case RUNNING = 'running';
+    case STARTING = 'starting';
+    case STOPPING = 'stopping';
     case STOPPED = 'stopped';
     case CREATING = 'creating';
     case INITIAL = 'initial';
+    case ERROR = 'error';
+    case SUSPENDING = 'suspending';
+    case UNSUSPENDING = 'unsuspending';
+    case SUSPENDED = 'suspended';
+    case DESTROYING = 'destroying';
+    case DESTROYED = 'destroyed';
+    case RECREATING = 'recreating';
+    case RESTORING = 'restoring';
+    case RECOVERY = 'recovery';
+    case STOPPING_RECOVERY = 'stopping_recovery';
 }

--- a/src/Resources/Dns/Snapshot.php
+++ b/src/Resources/Dns/Snapshot.php
@@ -82,7 +82,7 @@ final class Snapshot extends Resource
     {
         $version = $this->getApiVersion();
 
-        $response = $this->client->post(sprintf('/api/dns/%s/snapshots/%s/%d', $version, $domain, $snapshotId));
+        $response = $this->client->post(sprintf('/api/dns/%s/snapshots/%s/%d/restore', $version, $domain, $snapshotId));
 
         /** @var SuccessResponse */
         return $this->transform(SuccessResponse::class, $response);

--- a/src/Resources/Dns/Zone.php
+++ b/src/Resources/Dns/Zone.php
@@ -42,6 +42,108 @@ final class Zone extends Resource
     }
 
     /**
+     * Update zone records.
+     *
+     * Updates DNS records for the selected domain.
+     * Using `overwrite = true` will replace existing records with the provided ones.
+     * Otherwise existing records will be updated and new records will be added.
+     *
+     * @param string $domain Domain name
+     * @param array{
+     *      overwrite?: bool,
+     *      zone: array<int, array{
+     *          name: string,
+     *          records: array<int, array{content: string}>,
+     *          ttl?: int,
+     *          type: string
+     *      }>
+     *  } $data DNS records data
+     *
+     * @return SuccessResponse Success response
+     *
+     * @throws AuthenticationException When authentication fails (401)
+     * @throws ValidationException     When validation fails (422)
+     * @throws RateLimitException      When rate limit is exceeded (429)
+     * @throws ApiException            For other API errors
+     *
+     * @link https://developers.hostinger.com/#tag/dns-zone/PUT/api/dns/v1/zones/{domain}
+     */
+    public function update(string $domain, array $data): SuccessResponse
+    {
+        $version = $this->getApiVersion();
+        $response = $this->client->put(sprintf('/api/dns/%s/zones/%s', $version, $domain), $data);
+
+        /** @var SuccessResponse */
+        return $this->transform(SuccessResponse::class, $response);
+    }
+
+    /**
+     * Delete zone records.
+     *
+     * Deletes specific DNS records based on the provided filters (name and type).
+     *
+     * @param string $domain Domain name
+     * @param array{
+     *      filters: array<int, array{
+     *          name: string,
+     *          type: string
+     *      }>
+     *  } $data Filters for records to delete
+     *
+     * @return SuccessResponse Success response
+     *
+     * @throws AuthenticationException When authentication fails (401)
+     * @throws ValidationException     When validation fails (422)
+     * @throws RateLimitException      When rate limit is exceeded (429)
+     * @throws ApiException            For other API errors
+     *
+     * @link https://developers.hostinger.com/#tag/dns-zone/DELETE/api/dns/v1/zones/{domain}
+     */
+    public function delete(string $domain, array $data): SuccessResponse
+    {
+        $version = $this->getApiVersion();
+        $response = $this->client->delete(sprintf('/api/dns/%s/zones/%s', $version, $domain), $data);
+
+        /** @var SuccessResponse */
+        return $this->transform(SuccessResponse::class, $response);
+    }
+
+    /**
+     * Validate zone records before updating.
+     *
+     * If the validation is successful, the response will contain `200 Success` code.
+     * If there is validation error, the response will fail with `422 Validation error` code.
+     *
+     * @param string $domain Domain name
+     * @param array{
+     *      overwrite?: bool,
+     *      zone: array<int, array{
+     *          name: string,
+     *          records: array<int, array{content: string}>,
+     *          ttl?: int,
+     *          type: string
+     *      }>
+     *  } $data DNS records data to validate
+     *
+     * @return SuccessResponse Success response if validation passes
+     *
+     * @throws AuthenticationException When authentication fails (401)
+     * @throws ValidationException     When validation fails (422)
+     * @throws RateLimitException      When rate limit is exceeded (429)
+     * @throws ApiException            For other API errors
+     *
+     * @link https://developers.hostinger.com/#tag/dns-zone/POST/api/dns/v1/zones/{domain}/validate
+     */
+    public function validate(string $domain, array $data): SuccessResponse
+    {
+        $version = $this->getApiVersion();
+        $response = $this->client->post(sprintf('/api/dns/%s/zones/%s/validate', $version, $domain), $data);
+
+        /** @var SuccessResponse */
+        return $this->transform(SuccessResponse::class, $response);
+    }
+
+    /**
      * Reset DNS zone to the default records.
      *
      * @param string $domain Domain name

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
 use DerrickOb\HostingerApi\ClientInterface;
+use DerrickOb\HostingerApi\HttpClient\HttpClientInterface;
 use Faker\Factory;
 use Faker\Generator;
 
@@ -8,12 +9,17 @@ expect()->extend('toBeOne', fn () => $this->toBe(1));
 
 function createMockClient(): ClientInterface
 {
-    $client = \Mockery::mock(ClientInterface::class);
+    $client = Mockery::mock(ClientInterface::class);
 
     $client->shouldReceive('getApiVersion')
         ->andReturn('v1');
 
     return $client;
+}
+
+function createMockHttpClient(): HttpClientInterface
+{
+    return Mockery::mock(HttpClientInterface::class);
 }
 
 function faker(): Generator

--- a/tests/TestFactory.php
+++ b/tests/TestFactory.php
@@ -306,8 +306,6 @@ final class TestFactory
     {
         $faker = faker();
         $createdAt = $faker->dateTimeThisYear();
-        $expiresAt = (clone $createdAt)->modify('+1 year');
-        $nextBillingAt = (clone $createdAt)->modify('+1 month');
 
         return array_merge([
             'id' => $faker->regexify('[A-Za-z0-9]{15}'),
@@ -320,9 +318,8 @@ final class TestFactory
             'renewal_price' => $faker->numberBetween(1000, 5000),
             'auto_renew' => $faker->boolean(),
             'created_at' => $createdAt->format('Y-m-d\TH:i:s\Z'),
-            'expires_at' => $expiresAt->format('Y-m-d\TH:i:s\Z'),
-            'next_billing_at' => $nextBillingAt->format('Y-m-d\TH:i:s\Z'),
-            'canceled_at' => null,
+            'expires_at' => $faker->optional(0.9)?->dateTimeBetween($createdAt, '+2 years')->format('Y-m-d\TH:i:s\Z'),
+            'next_billing_at' => $faker->optional(0.8)?->dateTimeBetween($createdAt, '+1 year')->format('Y-m-d\TH:i:s\Z'),
         ], $attributes);
     }
 
@@ -413,10 +410,15 @@ final class TestFactory
     {
         $faker = faker();
 
+        $records = [];
+        for ($i = 0; $i < $faker->numberBetween(1, 5); $i++) {
+            $records[] = self::dnsName();
+        }
+
         return array_merge([
             'id' => $faker->randomNumber(6),
             'reason' => $faker->sentence(),
-            'snapshot' => json_encode(['zone' => 'records']),
+            'snapshot' => $records,
             'created_at' => $faker->dateTimeThisYear()->format('Y-m-d\TH:i:s\Z'),
         ], $attributes);
     }

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use DerrickOb\HostingerApi\Client;
+use DerrickOb\HostingerApi\Config;
+
+test('can perform a GET request', function (): void {
+    $httpClient = createMockHttpClient();
+    $config = new Config('test-token');
+    $client = new Client($config, $httpClient);
+    $response = ['data' => 'test-data'];
+
+    $httpClient->shouldReceive('request')
+        ->once()
+        ->with('GET', 'test-path', [])
+        ->andReturn($response);
+
+    $result = $client->get('test-path');
+
+    expect($result)->toBe($response);
+});
+
+test('can perform a GET request with query parameters', function (): void {
+    $httpClient = createMockHttpClient();
+    $config = new Config('test-token');
+    $client = new Client($config, $httpClient);
+    $response = ['data' => 'test-data'];
+
+    $httpClient->shouldReceive('request')
+        ->once()
+        ->with('GET', 'test-path', ['query' => ['key' => 'value']])
+        ->andReturn($response);
+
+    $result = $client->get('test-path', ['key' => 'value']);
+
+    expect($result)->toBe($response);
+});
+
+test('can perform a POST request', function (): void {
+    $httpClient = createMockHttpClient();
+    $config = new Config('test-token');
+    $client = new Client($config, $httpClient);
+    $response = ['data' => 'test-data'];
+
+    $httpClient->shouldReceive('request')
+        ->once()
+        ->with('POST', 'test-path', ['json' => ['key' => 'value']])
+        ->andReturn($response);
+
+    $result = $client->post('test-path', ['key' => 'value']);
+
+    expect($result)->toBe($response);
+});
+
+test('can perform a PUT request', function (): void {
+    $httpClient = createMockHttpClient();
+    $config = new Config('test-token');
+    $client = new Client($config, $httpClient);
+    $response = ['data' => 'test-data'];
+
+    $httpClient->shouldReceive('request')
+        ->once()
+        ->with('PUT', 'test-path', ['json' => ['key' => 'value']])
+        ->andReturn($response);
+
+    $result = $client->put('test-path', ['key' => 'value']);
+
+    expect($result)->toBe($response);
+});
+
+test('can perform a DELETE request', function (): void {
+    $httpClient = createMockHttpClient();
+    $config = new Config('test-token');
+    $client = new Client($config, $httpClient);
+    $response = ['message' => 'Response accepted'];
+
+    $httpClient->shouldReceive('request')
+        ->once()
+        ->with('DELETE', 'test-path', ['json' => ['key' => 'value']])
+        ->andReturn($response);
+
+    $result = $client->delete('test-path', ['key' => 'value']);
+
+    expect($result)->toBe($response);
+});
+
+test('can get the API version from config', function (): void {
+    $config = new Config('test-token', ['api_version' => 'v1']);
+    $client = new Client($config);
+
+    expect($client->getApiVersion())->toBe('v1');
+});

--- a/tests/Unit/Exceptions/ApiExceptionTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use DerrickOb\HostingerApi\Exceptions\ApiException;
+
+test('can get the correlation ID', function (): void {
+    $exception = new ApiException('Test message', 500, 'test-correlation-id');
+    expect($exception->getCorrelationId())->toBe('test-correlation-id');
+
+    $exceptionWithoutCorrelationId = new ApiException('Test message', 500);
+    expect($exceptionWithoutCorrelationId->getCorrelationId())->toBeNull();
+});

--- a/tests/Unit/Exceptions/ValidationExceptionTest.php
+++ b/tests/Unit/Exceptions/ValidationExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use DerrickOb\HostingerApi\Exceptions\ValidationException;
+
+test('can get validation errors', function (): void {
+    $errors = [
+        'field_1' => [
+            'field_1 must be string',
+            'field_1 is required',
+        ],
+    ];
+
+    $exception = new ValidationException('test message', 422, 'test-correlation-id', $errors);
+    expect($exception->getErrors())->toBe($errors);
+});

--- a/tests/Unit/Facades/BillingFacadeTest.php
+++ b/tests/Unit/Facades/BillingFacadeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use DerrickOb\HostingerApi\Facades\BillingFacade;
+use DerrickOb\HostingerApi\Resources\Billing\Catalog;
+use DerrickOb\HostingerApi\Resources\Billing\Order;
+use DerrickOb\HostingerApi\Resources\Billing\PaymentMethod;
+use DerrickOb\HostingerApi\Resources\Billing\Subscription;
+
+test('can access the catalog resource', function (): void {
+    $client = createMockClient();
+    $facade = new BillingFacade($client);
+    expect($facade->catalog())->toBeInstanceOf(Catalog::class);
+});
+
+test('can access the order resource', function (): void {
+    $client = createMockClient();
+    $facade = new BillingFacade($client);
+    expect($facade->orders())->toBeInstanceOf(Order::class);
+});
+
+test('can access the payment method resource', function (): void {
+    $client = createMockClient();
+    $facade = new BillingFacade($client);
+    expect($facade->paymentMethods())->toBeInstanceOf(PaymentMethod::class);
+});
+
+test('can access the subscription resource', function (): void {
+    $client = createMockClient();
+    $facade = new BillingFacade($client);
+    expect($facade->subscriptions())->toBeInstanceOf(Subscription::class);
+});

--- a/tests/Unit/Facades/DnsFacadeTest.php
+++ b/tests/Unit/Facades/DnsFacadeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use DerrickOb\HostingerApi\Facades\DnsFacade;
+use DerrickOb\HostingerApi\Resources\Dns\Snapshot;
+use DerrickOb\HostingerApi\Resources\Dns\Zone;
+
+test('can access the snapshot resource', function (): void {
+    $client = createMockClient();
+    $facade = new DnsFacade($client);
+    expect($facade->snapshots())->toBeInstanceOf(Snapshot::class);
+});
+
+test('can access the zone resource', function (): void {
+    $client = createMockClient();
+    $facade = new DnsFacade($client);
+    expect($facade->zones())->toBeInstanceOf(Zone::class);
+});

--- a/tests/Unit/Facades/DomainFacadeTest.php
+++ b/tests/Unit/Facades/DomainFacadeTest.php
@@ -1,0 +1,10 @@
+<?php
+
+use DerrickOb\HostingerApi\Facades\DomainFacade;
+use DerrickOb\HostingerApi\Resources\Domain\Portfolio;
+
+test('can access the portfolio resource', function (): void {
+    $client = createMockClient();
+    $facade = new DomainFacade($client);
+    expect($facade->portfolio())->toBeInstanceOf(Portfolio::class);
+});

--- a/tests/Unit/Facades/VpsFacadeTest.php
+++ b/tests/Unit/Facades/VpsFacadeTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use DerrickOb\HostingerApi\Facades\VpsFacade;
+use DerrickOb\HostingerApi\Resources\Vps\Action;
+use DerrickOb\HostingerApi\Resources\Vps\Backup;
+use DerrickOb\HostingerApi\Resources\Vps\DataCenter;
+use DerrickOb\HostingerApi\Resources\Vps\Firewall;
+use DerrickOb\HostingerApi\Resources\Vps\MalwareScanner;
+use DerrickOb\HostingerApi\Resources\Vps\OsTemplate;
+use DerrickOb\HostingerApi\Resources\Vps\PostInstallScript;
+use DerrickOb\HostingerApi\Resources\Vps\PtrRecord;
+use DerrickOb\HostingerApi\Resources\Vps\PublicKey;
+use DerrickOb\HostingerApi\Resources\Vps\Recovery;
+use DerrickOb\HostingerApi\Resources\Vps\Snapshot;
+use DerrickOb\HostingerApi\Resources\Vps\VirtualMachine;
+
+test('can access the action resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->actions())->toBeInstanceOf(Action::class);
+});
+
+test('can access the backup resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->backups())->toBeInstanceOf(Backup::class);
+});
+
+test('can access the data center resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->dataCenters())->toBeInstanceOf(DataCenter::class);
+});
+
+test('can access the firewall resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->firewalls())->toBeInstanceOf(Firewall::class);
+});
+
+test('can access the malware scanner resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->malwareScanner())->toBeInstanceOf(MalwareScanner::class);
+});
+
+test('can access the os template resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->templates())->toBeInstanceOf(OsTemplate::class);
+});
+
+test('can access the ptr record resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->ptrRecords())->toBeInstanceOf(PtrRecord::class);
+});
+
+test('can access the public key resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->publicKeys())->toBeInstanceOf(PublicKey::class);
+});
+
+test('can access the recovery resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->recovery())->toBeInstanceOf(Recovery::class);
+});
+
+test('can access the snapshot resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->snapshots())->toBeInstanceOf(Snapshot::class);
+});
+
+test('can access the virtual machine resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->virtualMachines())->toBeInstanceOf(VirtualMachine::class);
+});
+
+test('can access the post install script resource', function (): void {
+    $client = createMockClient();
+    $facade = new VpsFacade($client);
+    expect($facade->postInstallScripts())->toBeInstanceOf(PostInstallScript::class);
+});

--- a/tests/Unit/Resources/Billing/SubscriptionTest.php
+++ b/tests/Unit/Resources/Billing/SubscriptionTest.php
@@ -31,7 +31,6 @@ test('can list subscriptions', function (): void {
             'created_at' => $createdAt->format('Y-m-d\TH:i:s\Z'),
             'expires_at' => $expiresAt->format('Y-m-d\TH:i:s\Z'),
             'next_billing_at' => $nextBillingAt->format('Y-m-d\TH:i:s\Z'),
-            'canceled_at' => null,
         ];
     }
 


### PR DESCRIPTION
Reference: https://github.com/hostinger/api/blob/main/CHANGELOG.md#mon-apr-14-2025

Added:
1. DNS Zone:
- Update Zone Records
- Delete Zone Records
- Validate Zone Records
2. More response cases to `VirtualMachineState` enum.
3. More tests