### PR TITLE
Add domain availability and missing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A complete PHP SDK for interacting with the Hostinger API, allowing you to progr
     * [Initialize the Client](#initialize-the-client)
     * [Handle Errors](#handle-errors)
   * [Domains](#domains)
+    * [Availability](#availability)
+      * [Check Domain Availability](#check-domain-availability)
     * [Portfolio](#portfolio)
       * [Get Domain List](#get-domain-list)
   * [DNS](#dns)
@@ -183,6 +185,31 @@ try {
 
 ## Domains
 
+### Availability
+
+#### Check Domain Availability
+
+Checks the availability of a domain name across multiple TLDs.
+
+```php
+$data = [
+    'domain' => 'mydomain',
+    'tlds' => ['com', 'net', 'org'],
+    'with_alternatives' => false, // optional
+];
+
+$results = $hostinger->domains()->availability()->check($data);
+
+foreach ($results as $result) {
+    $result->domain; // mydomain.tld
+    $result->is_available; // true
+    $result->is_alternative; // false
+    $result->restriction; // null
+
+    $result->toArray(); // ['domain' => 'mydomain.com', 'is_available' => true, ...]
+}
+```
+
 ### Portfolio
 
 #### Get Domain List
@@ -227,7 +254,7 @@ foreach ($snapshot->snapshot as $recordGroup) {
     $recordGroup->ttl; // 14400
     foreach ($recordGroup->records as $recordValue) {
          $recordValue->content; // mydomain.tld.
-         $recordValue->disabled; // false
+         $recordValue->is_disabled; // false
     }
 }
 
@@ -282,9 +309,9 @@ foreach ($recordGroups as $group) {
 
     foreach ($group->records as $recordValue) {
         $recordValue->content; // mydomain.tld
-        $recordValue->disabled; // false
+        $recordValue->is_disabled; // false
 
-        $recordValue->toArray(); // ['content' => '...', 'disabled' => false]
+        $recordValue->toArray(); // ['content' => '...', 'is_disabled' => false]
     }
 
     $group->toArray(); // ['name' => 'www', 'records' => [[...], ...], 'ttl' => 14400, 'type' => 'A']
@@ -561,12 +588,12 @@ foreach ($subscriptions as $subscription) {
     $subscription->currency_code; // USD
     $subscription->total_price; // 1799
     $subscription->renewal_price; // 1799
-    $subscription->auto_renew; // true
+    $subscription->is_auto_renewed; // true
     $subscription->created_at->format('Y-m-d H:i:s'); // 2025-02-27 11:54:22
     $subscription->expires_at->format('Y-m-d H:i:s'); // 2025-03-27 11:54:22
     $subscription->next_billing_at ? $subscription->next_billing_at->format('Y-m-d H:i:s') : null; // 2025-02-28 11:54:22
 
-    $subscription->toArray(); // ['id' => '...', 'name' => 'KVM 1', 'status' => 'active', 'auto_renew' => true, ...]
+    $subscription->toArray(); // ['id' => '...', 'name' => 'KVM 1', 'status' => 'active', 'is_auto_renewed' => true, ...]
 }
 ```
 
@@ -780,7 +807,7 @@ $firewall = $hostinger->vps()->firewalls()->get($firewallId);
 
 $firewall->id; // 65224
 $firewall->name; // HTTP and SSH only
-$firewall->synced; // false
+$firewall->is_synced; // false
 $firewall->created_at->format('Y-m-d H:i:s'); // 2021-09-01 12:00:00
 $firewall->updated_at->format('Y-m-d H:i:s'); // 2021-09-01 12:00:00
 
@@ -795,7 +822,7 @@ foreach ($firewall->rules as $rule) {
     $rule->toArray(); // ['id' => 24541, 'action' => 'accept', 'protocol' => 'TCP', ...]
 }
 
-$firewall->toArray(); // ['id' => 65224, 'name' => '...', 'synced' => ..., 'rules' => [...], ...]
+$firewall->toArray(); // ['id' => 65224, 'name' => '...', 'is_synced' => ..., 'rules' => [...], ...]
 ```
 
 #### Delete Firewall
@@ -826,7 +853,7 @@ $firewalls->getTotal(); // 100
 foreach ($firewalls->getData() as $firewall) {
     $firewall->id; // 65224
     $firewall->name; // HTTP and SSH only
-    $firewall->synced; // false
+    $firewall->is_synced; // false
     $firewall->created_at->format('Y-m-d H:i:s'); // 2021-09-01 12:00:00
     $firewall->updated_at->format('Y-m-d H:i:s'); // 2021-09-01 12:00:00
 
@@ -841,7 +868,7 @@ foreach ($firewalls->getData() as $firewall) {
         $rule->toArray(); // ['id' => 24541, 'action' => 'accept', 'protocol' => 'TCP', ...]
     }
 
-    $firewall->toArray(); // ['id' => 65224, 'name' => '...', 'synced' => false, 'rules' => [[...], ...], ...]
+    $firewall->toArray(); // ['id' => 65224, 'name' => '...', 'is_synced' => false, 'rules' => [[...], ...], ...]
 }
 
 $firewalls->toArray(); // ['data' => [[...], ...], 'meta' => ['current_page' => 1, ...]]
@@ -860,12 +887,12 @@ $firewall = $hostinger->vps()->firewalls()->create($data);
 
 $firewall->id; // 65224
 $firewall->name; // HTTP and SSH only
-$firewall->synced; // false
+$firewall->is_synced; // false
 $firewall->rules; // empty array []
 $firewall->created_at->format('Y-m-d H:i:s'); // 2021-09-01 12:00:00
 $firewall->updated_at->format('Y-m-d H:i:s'); // 2021-09-01 12:00:00
 
-$firewall->toArray(); // ['id' => 65224, 'name' => 'HTTP and SSH only', 'synced' => false, 'rules' => [], ...]
+$firewall->toArray(); // ['id' => 65224, 'name' => 'HTTP and SSH only', 'is_synced' => false, 'rules' => [], ...]
 ```
 
 #### Update Firewall Rule

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
     },
     "scripts": {
         "test": "pest",
+        "test:coverage": "XDEBUG_MODE=coverage pest --coverage",
         "stan": "phpstan analyze",
         "cs": "php-cs-fixer fix --allow-risky=yes --dry-run --diff",
         "rector": "rector process --dry-run",

--- a/src/Data/Billing/Subscription.php
+++ b/src/Data/Billing/Subscription.php
@@ -40,7 +40,7 @@ final class Subscription extends Data
     public int $renewal_price;
 
     /** @var bool Whether the subscription will automatically renew. */
-    public bool $auto_renew;
+    public bool $is_auto_renewed;
 
     /** @var DateTimeImmutable Date and time when the subscription was created. */
     public DateTimeImmutable $created_at;
@@ -61,7 +61,7 @@ final class Subscription extends Data
      *      currency_code: string,
      *      total_price: int,
      *      renewal_price: int,
-     *      auto_renew: bool,
+     *      is_auto_renewed: bool,
      *      created_at: string,
      *      expires_at?: string|null,
      *      next_billing_at?: string|null
@@ -79,7 +79,7 @@ final class Subscription extends Data
         $this->currency_code = $data['currency_code'];
         $this->total_price = $data['total_price'];
         $this->renewal_price = $data['renewal_price'];
-        $this->auto_renew = $data['auto_renew'];
+        $this->is_auto_renewed = $data['is_auto_renewed'];
         $this->created_at = new DateTimeImmutable($data['created_at']);
         $this->expires_at = isset($data['expires_at']) ? new DateTimeImmutable($data['expires_at']) : null;
         $this->next_billing_at = isset($data['next_billing_at']) ? new DateTimeImmutable($data['next_billing_at']) : null;

--- a/src/Data/Dns/NameRecord.php
+++ b/src/Data/Dns/NameRecord.php
@@ -15,17 +15,17 @@ final class NameRecord extends Data
     public string $content;
 
     /** @var bool Flag to mark name record as disabled. */
-    public bool $disabled;
+    public bool $is_disabled;
 
     /**
      * @param array{
      *      content: string,
-     *      disabled?: bool
+     *      is_disabled?: bool
      *  } $data
      */
     public function __construct(array $data)
     {
         $this->content = $data['content'];
-        $this->disabled = $data['disabled'] ?? false;
+        $this->is_disabled = $data['is_disabled'] ?? false;
     }
 }

--- a/src/Data/Domain/Availability.php
+++ b/src/Data/Domain/Availability.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Data\Domain;
+
+use DerrickOb\HostingerApi\Data\Data;
+
+/**
+ * Represents the availability status of a domain name.
+ */
+final class Availability extends Data
+{
+    /** @var string Domain name checked. */
+    public string $domain;
+
+    /** @var bool Whether the domain is available for registration. */
+    public bool $is_available;
+
+    /** @var bool Whether this domain was provided as an alternative suggestion. */
+    public bool $is_alternative;
+
+    /** @var string|null Special rules or restrictions for registering this TLD. */
+    public ?string $restriction;
+
+    /**
+     * @param array{
+     *      domain: string,
+     *      is_available: bool,
+     *      is_alternative: bool,
+     *      restriction?: string|null
+     *  } $data
+     */
+    public function __construct(array $data)
+    {
+        $this->domain = $data['domain'];
+        $this->is_available = $data['is_available'];
+        $this->is_alternative = $data['is_alternative'];
+        $this->restriction = $data['restriction'] ?? null;
+    }
+}

--- a/src/Data/Vps/Firewall.php
+++ b/src/Data/Vps/Firewall.php
@@ -20,7 +20,7 @@ final class Firewall extends Data
     public string $name;
 
     /** @var bool Whether the firewall is in sync with all virtual machines using it. */
-    public bool $synced;
+    public bool $is_synced;
 
     /** @var array<int, FirewallRule> List of rules defined in this firewall. */
     public array $rules;
@@ -35,7 +35,7 @@ final class Firewall extends Data
      * @param array{
      *      id: int,
      *      name: string,
-     *      synced: bool,
+     *      is_synced: bool,
      *      rules: array<int, array{
      *          id: int,
      *          action: string,
@@ -54,7 +54,7 @@ final class Firewall extends Data
     {
         $this->id = $data['id'];
         $this->name = $data['name'];
-        $this->synced = $data['synced'];
+        $this->is_synced = $data['is_synced'];
         $this->rules = array_map(
             fn (array $ruleData): FirewallRule => new FirewallRule($ruleData),
             $data['rules']

--- a/src/Facades/DomainFacade.php
+++ b/src/Facades/DomainFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DerrickOb\HostingerApi\Facades;
 
 use DerrickOb\HostingerApi\ClientInterface;
+use DerrickOb\HostingerApi\Resources\Domain\Availability;
 use DerrickOb\HostingerApi\Resources\Domain\Portfolio;
 
 /**
@@ -29,5 +30,17 @@ final class DomainFacade
     public function portfolio(): Portfolio
     {
         return new Portfolio($this->client);
+    }
+
+    /**
+     * Access the Availability resource.
+     *
+     * @link https://developers.hostinger.com/#tag/domains-availability
+     *
+     * @return Availability The availability resource instance
+     */
+    public function availability(): Availability
+    {
+        return new Availability($this->client);
     }
 }

--- a/src/Resources/Domain/Availability.php
+++ b/src/Resources/Domain/Availability.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Resources\Domain;
+
+use DerrickOb\HostingerApi\Data\Domain\Availability as AvailabilityData;
+use DerrickOb\HostingerApi\Exceptions\ApiException;
+use DerrickOb\HostingerApi\Exceptions\AuthenticationException;
+use DerrickOb\HostingerApi\Exceptions\RateLimitException;
+use DerrickOb\HostingerApi\Exceptions\ValidationException;
+use DerrickOb\HostingerApi\Resources\Resource;
+
+/**
+ * Resource for interacting with the Domains Availability API.
+ *
+ * @link https://developers.hostinger.com/#tag/domains-availability
+ */
+final class Availability extends Resource
+{
+    /**
+     * Check domain availability.
+     *
+     * Checks the availability of a domain name across multiple TLDs.
+     *
+     * @param array{
+     *     domain: string,
+     *     tlds: array<int, string>,
+     *     with_alternatives?: bool
+     * } $data Domain name and TLDs to check
+     *
+     * @return array<AvailabilityData> List of availability results
+     *
+     * @throws AuthenticationException When authentication fails (401)
+     * @throws ValidationException     When validation fails (422)
+     * @throws RateLimitException      When rate limit is exceeded (429)
+     * @throws ApiException            For other API errors
+     *
+     * @link https://developers.hostinger.com/#tag/domains-availability/POST/api/domains/v1/availability
+     */
+    public function check(array $data): array
+    {
+        $version = $this->getApiVersion();
+        $response = $this->client->post(sprintf('/api/domains/%s/availability', $version), $data);
+
+        /** @var array<AvailabilityData> */
+        return $this->transform(AvailabilityData::class, $response);
+    }
+}

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Resources;
 
 use DerrickOb\HostingerApi\ClientInterface;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use DerrickOb\HostingerApi\ClientInterface;
 use DerrickOb\HostingerApi\HttpClient\HttpClientInterface;
 use Faker\Factory;

--- a/tests/TestFactory.php
+++ b/tests/TestFactory.php
@@ -157,7 +157,7 @@ final class TestFactory
         return array_merge([
             'id' => $faker->randomNumber(5),
             'name' => implode(' ', (array) $faker->words(3, true)) . ' Firewall',
-            'synced' => $faker->boolean(80),
+            'is_synced' => $faker->boolean(80),
             'rules' => $rules,
             'created_at' => $createdAt->format('Y-m-d\TH:i:s\Z'),
             'updated_at' => $updatedAt->format('Y-m-d\TH:i:s\Z'),
@@ -316,7 +316,7 @@ final class TestFactory
             'currency_code' => 'USD',
             'total_price' => $faker->numberBetween(1000, 5000),
             'renewal_price' => $faker->numberBetween(1000, 5000),
-            'auto_renew' => $faker->boolean(),
+            'is_auto_renewed' => $faker->boolean(),
             'created_at' => $createdAt->format('Y-m-d\TH:i:s\Z'),
             'expires_at' => $faker->optional(0.9)?->dateTimeBetween($createdAt, '+2 years')->format('Y-m-d\TH:i:s\Z'),
             'next_billing_at' => $faker->optional(0.8)?->dateTimeBetween($createdAt, '+1 year')->format('Y-m-d\TH:i:s\Z'),
@@ -436,7 +436,7 @@ final class TestFactory
 
         return array_merge([
             'content' => $faker->randomElement([$faker->ipv4(), $faker->domainName() . '.']),
-            'disabled' => $faker->boolean(10),
+            'is_disabled' => $faker->boolean(10),
         ], $attributes);
     }
 

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit;
+
 use DerrickOb\HostingerApi\Client;
 use DerrickOb\HostingerApi\Config;
 

--- a/tests/Unit/Data/DataTest.php
+++ b/tests/Unit/Data/DataTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Data;
+
+test('can create a DTO from array', function (): void {
+    $data = ['id' => 1, 'name' => 'Test'];
+    $dto = TestDataDto::fromArray($data);
+    expect($dto)->toBeInstanceOf(TestDataDto::class)
+        ->and($dto->id)->toBe(1)
+        ->and($dto->name)->toBe('Test');
+});
+
+test('can create a DTO collection', function (): void {
+    $items = [
+        ['id' => 1, 'name' => 'Test 1'],
+        ['id' => 2, 'name' => 'Test 2'],
+    ];
+    $collection = TestDataDto::collection($items);
+
+    expect($collection)->toBeArray()
+        ->and($collection)->toHaveCount(2)
+        ->and($collection[0])->toBeInstanceOf(TestDataDto::class)
+        ->and($collection[0]->id)->toBe(1)
+        ->and($collection[1])->toBeInstanceOf(TestDataDto::class)
+        ->and($collection[1]->id)->toBe(2);
+});
+
+test('can convert to array', function (): void {
+    $data = ['id' => 1, 'name' => 'Test'];
+    $dto = new TestDataDto($data);
+    $result = $dto->toArray();
+    expect($result)->toBeArray()
+        ->and($result)->toHaveKey('id', 1)
+        ->and($result)->toHaveKey('name', 'Test');
+});
+
+test('can serialize to json', function (): void {
+    $data = ['id' => 1, 'name' => 'Test'];
+    $dto = new TestDataDto($data);
+
+    $result = $dto->jsonSerialize();
+    expect($result)->toBeArray()
+        ->and($result)->toHaveKey('id', 1)
+        ->and($result)->toHaveKey('name', 'Test');
+
+    $json = json_encode($dto);
+    expect($json)->toBe('{"id":1,"name":"Test"}');
+});

--- a/tests/Unit/Data/PaginatedResponseTest.php
+++ b/tests/Unit/Data/PaginatedResponseTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Data;
+
+use DerrickOb\HostingerApi\Data\Domain\Domain;
+use DerrickOb\HostingerApi\Data\PaginatedResponse;
+use DerrickOb\HostingerApi\Tests\TestFactory;
+
+test('can create paginated response and access data', function (): void {
+    $items = [
+        TestFactory::domain(['id' => 1, 'name' => 'domain1.com']),
+        TestFactory::domain(['id' => 2, 'name' => 'domain2.com']),
+    ];
+    $meta = [
+        'current_page' => 1,
+        'per_page' => 10,
+        'total' => 2,
+    ];
+    $responseArray = ['data' => $items, 'meta' => $meta];
+
+    $paginatedResponse = new PaginatedResponse($responseArray, Domain::class);
+
+    expect($paginatedResponse->getData())->toBeArray()->toHaveCount(2)
+        ->and($paginatedResponse->getData()[0])->toBeInstanceOf(Domain::class)
+        ->and($paginatedResponse->getData()[0]->id)->toBe(1);
+});
+
+test('can access pagination metadata', function (): void {
+    $items = [TestFactory::domain(['id' => 1])];
+    $meta = [
+        'current_page' => 2,
+        'per_page' => 5,
+        'total' => 11,
+    ];
+    $responseArray = ['data' => $items, 'meta' => $meta];
+
+    $paginatedResponse = new PaginatedResponse($responseArray, Domain::class);
+
+    expect($paginatedResponse->getMeta())->toBe($meta)
+        ->and($paginatedResponse->getCurrentPage())->toBe(2)
+        ->and($paginatedResponse->getPerPage())->toBe(5)
+        ->and($paginatedResponse->getTotal())->toBe(11);
+});
+
+test('handles response without meta key', function (): void {
+    $items = [
+        TestFactory::domain(['id' => 1]),
+        TestFactory::domain(['id' => 2]),
+    ];
+    $responseArray = ['data' => $items];
+
+    $paginatedResponse = new PaginatedResponse($responseArray, Domain::class);
+
+    $meta = [
+        'current_page' => 1,
+        'per_page' => 2,
+        'total' => 2,
+    ];
+
+    expect($paginatedResponse->getMeta())->toBe($meta)
+        ->and($paginatedResponse->getCurrentPage())->toBe(1)
+        ->and($paginatedResponse->getPerPage())->toBe(2)
+        ->and($paginatedResponse->getTotal())->toBe(2)
+        ->and($paginatedResponse->getData())->toHaveCount(2);
+});
+
+test('can convert paginated response to array', function (): void {
+    $items = [
+        TestFactory::domain(['id' => 1, 'name' => 'domain1.com']),
+    ];
+    $meta = [
+        'current_page' => 1,
+        'per_page' => 10,
+        'total' => 1,
+    ];
+    $responseArray = ['data' => $items, 'meta' => $meta];
+
+    $paginatedResponse = new PaginatedResponse($responseArray, Domain::class);
+    $arrayResult = $paginatedResponse->toArray();
+
+    expect($arrayResult)->toBeArray()
+        ->and($arrayResult['meta'])->toBe($meta)
+        ->and($arrayResult['data'])->toBeArray()->toHaveCount(1)
+        ->and($arrayResult['data'][0]['id'])->toBe(1)
+        ->and($arrayResult['data'][0]['name'])->toBe('domain1.com');
+});
+
+test('can serialize paginated response to json', function (): void {
+    $items = [
+        TestFactory::domain(['id' => 1, 'name' => 'domain1.com']),
+    ];
+    $meta = [
+        'current_page' => 1,
+        'per_page' => 10,
+        'total' => 1,
+    ];
+    $responseArray = ['data' => $items, 'meta' => $meta];
+
+    $paginatedResponse = new PaginatedResponse($responseArray, Domain::class);
+    $jsonResult = json_encode($paginatedResponse);
+    $decodedResult = json_decode((string) $jsonResult, true);
+
+    expect($decodedResult)->toBeArray()
+        ->and($decodedResult['meta'])->toBe($meta)
+        ->and($decodedResult['data'])->toBeArray()->toHaveCount(1)
+        ->and($decodedResult['data'][0]['id'])->toBe(1)
+        ->and($decodedResult['data'][0]['name'])->toBe('domain1.com');
+});

--- a/tests/Unit/Data/ResponseFactoryTest.php
+++ b/tests/Unit/Data/ResponseFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Data;
+
+use DerrickOb\HostingerApi\Data\Domain\Domain;
+use DerrickOb\HostingerApi\Data\PaginatedResponse;
+use DerrickOb\HostingerApi\Data\ResponseFactory;
+use DerrickOb\HostingerApi\Tests\TestFactory;
+
+test('create handles single item', function (): void {
+    $data = TestFactory::domain(['id' => 1]);
+    $result = ResponseFactory::create(Domain::class, $data);
+
+    expect($result)->toBeInstanceOf(Domain::class)
+        ->and($result->id)->toBe(1);
+});
+
+test('createCollection handles multiple items', function (): void {
+    $data = [
+        TestFactory::domain(['id' => 1]),
+        TestFactory::domain(['id' => 2]),
+    ];
+    $result = ResponseFactory::createCollection(Domain::class, $data);
+
+    expect($result)->toBeArray()->toHaveCount(2)
+        ->and($result[0])->toBeInstanceOf(Domain::class)
+        ->and($result[0]->id)->toBe(1);
+});
+
+test('createCollection handles empty array', function (): void {
+    $result = ResponseFactory::createCollection(Domain::class, []);
+    expect($result)->toBeArray()->toBeEmpty();
+});
+
+test('createPaginated handles paginated response', function (): void {
+    $data = [
+        'data' => [TestFactory::domain(['id' => 1])],
+        'meta' => ['current_page' => 1, 'per_page' => 10, 'total' => 1],
+    ];
+    $result = ResponseFactory::createPaginated(Domain::class, $data);
+
+    expect($result)->toBeInstanceOf(PaginatedResponse::class)
+        ->and($result->getCurrentPage())->toBe(1)
+        ->and($result->getData())->toHaveCount(1);
+});
+
+test('createResponse identifies single item', function (): void {
+    $data = TestFactory::domain(['id' => 1]);
+
+    /** @var Domain $result */
+    $result = ResponseFactory::createResponse(Domain::class, $data);
+
+    expect($result)->toBeInstanceOf(Domain::class)
+        ->and($result->id)->toBe(1);
+});
+
+test('createResponse identifies collection', function (): void {
+    $data = [
+        TestFactory::domain(['id' => 1]),
+        TestFactory::domain(['id' => 2]),
+    ];
+
+    /** @var array<Domain> $result */
+    $result = ResponseFactory::createResponse(Domain::class, $data);
+
+    expect($result)->toBeArray()->toHaveCount(2)
+        ->and($result[0])->toBeInstanceOf(Domain::class);
+});
+
+test('createResponse identifies paginated response', function (): void {
+    $data = [
+        'data' => [TestFactory::domain(['id' => 1])],
+        'meta' => ['current_page' => 1, 'per_page' => 10, 'total' => 1],
+    ];
+    $result = ResponseFactory::createResponse(Domain::class, $data);
+
+    expect($result)->toBeInstanceOf(PaginatedResponse::class);
+});
+
+test('createResponse handles empty array', function (): void {
+    $result = ResponseFactory::createResponse(Domain::class, []);
+    expect($result)->toBeArray()->toBeEmpty();
+});

--- a/tests/Unit/Data/TestDataDto.php
+++ b/tests/Unit/Data/TestDataDto.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Data;
+
+use DerrickOb\HostingerApi\Data\Data;
+
+final class TestDataDto extends Data
+{
+    public int $id;
+
+    public string $name;
+
+    /**
+     * @param array{
+     *     id: int,
+     *     name: string,
+     * } $data
+     */
+    public function __construct(array $data)
+    {
+        $this->id = $data['id'];
+        $this->name = $data['name'];
+    }
+}

--- a/tests/Unit/Exceptions/ApiExceptionTest.php
+++ b/tests/Unit/Exceptions/ApiExceptionTest.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Exceptions;
+
 use DerrickOb\HostingerApi\Exceptions\ApiException;
 
 test('can get the correlation ID', function (): void {

--- a/tests/Unit/Exceptions/ValidationExceptionTest.php
+++ b/tests/Unit/Exceptions/ValidationExceptionTest.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Exceptions;
+
 use DerrickOb\HostingerApi\Exceptions\ValidationException;
 
 test('can get validation errors', function (): void {

--- a/tests/Unit/Facades/BillingFacadeTest.php
+++ b/tests/Unit/Facades/BillingFacadeTest.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Facades;
+
 use DerrickOb\HostingerApi\Facades\BillingFacade;
 use DerrickOb\HostingerApi\Resources\Billing\Catalog;
 use DerrickOb\HostingerApi\Resources\Billing\Order;

--- a/tests/Unit/Facades/DnsFacadeTest.php
+++ b/tests/Unit/Facades/DnsFacadeTest.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Facades;
+
 use DerrickOb\HostingerApi\Facades\DnsFacade;
 use DerrickOb\HostingerApi\Resources\Dns\Snapshot;
 use DerrickOb\HostingerApi\Resources\Dns\Zone;

--- a/tests/Unit/Facades/DomainFacadeTest.php
+++ b/tests/Unit/Facades/DomainFacadeTest.php
@@ -1,10 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Facades;
+
 use DerrickOb\HostingerApi\Facades\DomainFacade;
+use DerrickOb\HostingerApi\Resources\Domain\Availability;
 use DerrickOb\HostingerApi\Resources\Domain\Portfolio;
 
 test('can access the portfolio resource', function (): void {
     $client = createMockClient();
     $facade = new DomainFacade($client);
     expect($facade->portfolio())->toBeInstanceOf(Portfolio::class);
+});
+
+test('can access the availability resource', function (): void {
+    $client = createMockClient();
+    $facade = new DomainFacade($client);
+    expect($facade->availability())->toBeInstanceOf(Availability::class);
 });

--- a/tests/Unit/Facades/VpsFacadeTest.php
+++ b/tests/Unit/Facades/VpsFacadeTest.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Facades;
+
 use DerrickOb\HostingerApi\Facades\VpsFacade;
 use DerrickOb\HostingerApi\Resources\Vps\Action;
 use DerrickOb\HostingerApi\Resources\Vps\Backup;

--- a/tests/Unit/HostingerTest.php
+++ b/tests/Unit/HostingerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit;
+
+use DerrickOb\HostingerApi\ClientInterface;
 use DerrickOb\HostingerApi\Facades\BillingFacade;
 use DerrickOb\HostingerApi\Facades\DnsFacade;
 use DerrickOb\HostingerApi\Facades\DomainFacade;
@@ -29,4 +34,9 @@ test('can access dns facade', function (): void {
 test('can access vps facade', function (): void {
     $hostinger = new Hostinger('test-token');
     expect($hostinger->vps())->toBeInstanceOf(VpsFacade::class);
+});
+
+test('can get the client instance', function (): void {
+    $hostinger = new Hostinger('test-token');
+    expect($hostinger->getClient())->toBeInstanceOf(ClientInterface::class);
 });

--- a/tests/Unit/Resources/Billing/CatalogTest.php
+++ b/tests/Unit/Resources/Billing/CatalogTest.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Billing;
+
 use DerrickOb\HostingerApi\Data\Billing\CatalogItem;
 use DerrickOb\HostingerApi\Resources\Billing\Catalog;
 use DerrickOb\HostingerApi\Tests\TestFactory;

--- a/tests/Unit/Resources/Billing/OrderTest.php
+++ b/tests/Unit/Resources/Billing/OrderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Billing;
 
 use DerrickOb\HostingerApi\Data\Billing\Order as OrderData;

--- a/tests/Unit/Resources/Billing/PaymentMethodTest.php
+++ b/tests/Unit/Resources/Billing/PaymentMethodTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Billing;
 
 use DerrickOb\HostingerApi\Data\Billing\PaymentMethod as PaymentMethodData;

--- a/tests/Unit/Resources/Billing/SubscriptionTest.php
+++ b/tests/Unit/Resources/Billing/SubscriptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Billing;
 
 use DerrickOb\HostingerApi\Data\Billing\Subscription as SubscriptionData;
@@ -27,7 +29,7 @@ test('can list subscriptions', function (): void {
             'currency_code' => 'USD',
             'total_price' => $faker->numberBetween(1000, 5000),
             'renewal_price' => $faker->numberBetween(1000, 5000),
-            'auto_renew' => $faker->boolean(),
+            'is_auto_renewed' => $faker->boolean(),
             'created_at' => $createdAt->format('Y-m-d\TH:i:s\Z'),
             'expires_at' => $expiresAt->format('Y-m-d\TH:i:s\Z'),
             'next_billing_at' => $nextBillingAt->format('Y-m-d\TH:i:s\Z'),
@@ -52,6 +54,7 @@ test('can list subscriptions', function (): void {
         ->and($response[0]->name)->toBe($subscriptions[0]['name'])
         ->and($response[0]->status)->toBe(SubscriptionStatus::ACTIVE)
         ->and($response[0]->billing_period)->toBe($subscriptions[0]['billing_period'])
+        ->and($response[0]->is_auto_renewed)->toBe($subscriptions[0]['is_auto_renewed'])
         ->and($response[1]->status)->toBe(SubscriptionStatus::NOT_RENEWING);
 
     $periodUnit = PeriodUnit::from($subscriptions[0]['billing_period_unit']);

--- a/tests/Unit/Resources/Dns/SnapshotTest.php
+++ b/tests/Unit/Resources/Dns/SnapshotTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Dns;
 
 use DerrickOb\HostingerApi\Data\Dns\Name;
@@ -57,7 +59,8 @@ test('can get specific DNS snapshot with content', function (): void {
         ->and($response->reason)->toBe($snapshot['reason'])
         ->and($response->snapshot)->toBeArray()
         ->and($response->snapshot[0])->toBeInstanceOf(Name::class)
-        ->and($response->snapshot[0]->name)->toBe($snapshot['snapshot'][0]['name']);
+        ->and($response->snapshot[0]->name)->toBe($snapshot['snapshot'][0]['name'])
+        ->and($response->snapshot[0]->records[0]->is_disabled)->toBe($snapshot['snapshot'][0]['records'][0]['is_disabled']);
 });
 
 test('can restore DNS snapshot', function (): void {

--- a/tests/Unit/Resources/Dns/ZoneTest.php
+++ b/tests/Unit/Resources/Dns/ZoneTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Dns;
 
 use DerrickOb\HostingerApi\Data\Dns\Name;
@@ -34,7 +36,8 @@ test('can get DNS zone records', function (): void {
         ->and($response[0]->ttl)->toBe($records[0]['ttl'])
         ->and($response[0]->type)->toBe($records[0]['type'])
         ->and($response[0]->records)->toBeArray()
-        ->and($response[0]->records[0]->content)->toBe($records[0]['records'][0]['content']);
+        ->and($response[0]->records[0]->content)->toBe($records[0]['records'][0]['content'])
+        ->and($response[0]->records[0]->is_disabled)->toBe($records[0]['records'][0]['is_disabled']);
 });
 
 test('can update DNS zone records', function (): void {

--- a/tests/Unit/Resources/Domain/AvailaibilityTest.php
+++ b/tests/Unit/Resources/Domain/AvailaibilityTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Domain;
+
+use DerrickOb\HostingerApi\Data\Domain\Availability as AvailabilityData;
+use DerrickOb\HostingerApi\Resources\Domain\Availability;
+
+test('can check domain availability', function (): void {
+    $faker = faker();
+    $domainName = $faker->domainWord();
+    $tlds = ['com', 'net', 'org'];
+
+    $data = [
+        'domain' => $domainName,
+        'tlds' => $tlds,
+        'with_alternatives' => false,
+    ];
+
+    $results = [
+        [
+            'domain' => $domainName . '.com',
+            'is_available' => true,
+            'is_alternative' => false,
+            'restriction' => null,
+        ],
+        [
+            'domain' => $domainName . '.net',
+            'is_available' => false,
+            'is_alternative' => false,
+            'restriction' => null,
+        ],
+        [
+            'domain' => $domainName . '.org',
+            'is_available' => true,
+            'is_alternative' => false,
+            'restriction' => 'Requires specific organization type',
+        ],
+    ];
+
+    $client = createMockClient();
+    $client->shouldReceive('post')
+        ->with('/api/domains/v1/availability', $data)
+        ->once()
+        ->andReturn($results);
+
+    $resource = new Availability($client);
+
+    /** @var array<AvailabilityData> $response */
+    $response = $resource->check($data);
+
+    expect($response)->toBeArray()
+        ->and($response)->toHaveCount(3)
+        ->and($response[0])->toBeInstanceOf(AvailabilityData::class)
+        ->and($response[0]->domain)->toBe($domainName . '.com')
+        ->and($response[0]->is_available)->toBeTrue()
+        ->and($response[0]->is_alternative)->toBeFalse()
+        ->and($response[0]->restriction)->toBeNull()
+        ->and($response[1]->domain)->toBe($domainName . '.net')
+        ->and($response[1]->is_available)->toBeFalse()
+        ->and($response[2]->domain)->toBe($domainName . '.org')
+        ->and($response[2]->is_available)->toBeTrue()
+        ->and($response[2]->restriction)->toBe('Requires specific organization type');
+});
+
+test('can check domain availability with alternatives', function (): void {
+    $faker = faker();
+    $domainName = $faker->domainWord();
+    $tlds = ['shop'];
+
+    $data = [
+        'domain' => $domainName,
+        'tlds' => $tlds,
+        'with_alternatives' => true,
+    ];
+
+    $results = [
+        [
+            'domain' => $domainName . '.shop',
+            'is_available' => false,
+            'is_alternative' => false,
+            'restriction' => null,
+        ],
+        [
+            'domain' => $domainName . '-store.com',
+            'is_available' => true,
+            'is_alternative' => true,
+            'restriction' => null,
+        ],
+    ];
+
+    $client = createMockClient();
+    $client->shouldReceive('post')
+        ->with('/api/domains/v1/availability', $data)
+        ->once()
+        ->andReturn($results);
+
+    $resource = new Availability($client);
+
+    /** @var array<AvailabilityData> $response */
+    $response = $resource->check($data);
+
+    expect($response)->toBeArray()
+        ->and($response)->toHaveCount(2)
+        ->and($response[0]->is_available)->toBeFalse()
+        ->and($response[1]->is_available)->toBeTrue()
+        ->and($response[1]->is_alternative)->toBeTrue();
+});

--- a/tests/Unit/Resources/Domain/PortfolioTest.php
+++ b/tests/Unit/Resources/Domain/PortfolioTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Domain;
 
 use DerrickOb\HostingerApi\Data\Domain\Domain;

--- a/tests/Unit/Resources/Vps/ActionTest.php
+++ b/tests/Unit/Resources/Vps/ActionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\PaginatedResponse;

--- a/tests/Unit/Resources/Vps/BackupTest.php
+++ b/tests/Unit/Resources/Vps/BackupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\PaginatedResponse;

--- a/tests/Unit/Resources/Vps/DataCenterTest.php
+++ b/tests/Unit/Resources/Vps/DataCenterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\Vps\DataCenter as DataCenterData;

--- a/tests/Unit/Resources/Vps/FirewallTest.php
+++ b/tests/Unit/Resources/Vps/FirewallTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\PaginatedResponse;
@@ -39,6 +41,7 @@ test('can list firewalls', function (): void {
         ->and($response->getData()[0])->toBeInstanceOf(FirewallData::class)
         ->and($response->getData()[0]->id)->toBe($firewall['id'])
         ->and($response->getData()[0]->name)->toBe($firewall['name'])
+        ->and($response->getData()[0]->is_synced)->toBe($firewall['is_synced'])
         ->and($response->getData()[0]->rules)->toBeArray();
 });
 
@@ -59,6 +62,7 @@ test('can get firewall details', function (): void {
     expect($response)->toBeInstanceOf(FirewallData::class)
         ->and($response->id)->toBe($firewallId)
         ->and($response->name)->toBe($firewall['name'])
+        ->and($response->is_synced)->toBe($firewall['is_synced'])
         ->and($response->rules)->toBeArray();
 
     foreach ($response->rules as $index => $rule) {
@@ -85,7 +89,8 @@ test('can create a firewall', function (): void {
     $response = $resource->create(['name' => $firewallName]);
 
     expect($response)->toBeInstanceOf(FirewallData::class)
-        ->and($response->name)->toBe($firewallName);
+        ->and($response->name)->toBe($firewallName)
+        ->and($response->is_synced)->toBe($firewall['is_synced']);
 });
 
 test('can create a firewall rule', function (): void {

--- a/tests/Unit/Resources/Vps/MalwareScannerTest.php
+++ b/tests/Unit/Resources/Vps/MalwareScannerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\Vps\Action as ActionData;

--- a/tests/Unit/Resources/Vps/OsTemplateTest.php
+++ b/tests/Unit/Resources/Vps/OsTemplateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\Vps\OsTemplate as OsTemplateData;

--- a/tests/Unit/Resources/Vps/PostInstallScriptTest.php
+++ b/tests/Unit/Resources/Vps/PostInstallScriptTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\PaginatedResponse;

--- a/tests/Unit/Resources/Vps/PtrRecordTest.php
+++ b/tests/Unit/Resources/Vps/PtrRecordTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\Vps\Action as ActionData;

--- a/tests/Unit/Resources/Vps/PublicKeyTest.php
+++ b/tests/Unit/Resources/Vps/PublicKeyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\PaginatedResponse;

--- a/tests/Unit/Resources/Vps/RecoveryTest.php
+++ b/tests/Unit/Resources/Vps/RecoveryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\Vps\Action as ActionData;

--- a/tests/Unit/Resources/Vps/SnapshotTest.php
+++ b/tests/Unit/Resources/Vps/SnapshotTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DerrickOb\HostingerApi\Tests\Unit\Resources\Vps;
 
 use DerrickOb\HostingerApi\Data\Vps\Action as ActionData;


### PR DESCRIPTION
Reference: https://github.com/hostinger/api/blob/main/CHANGELOG.md#tue-apr-22-2025


Changes:
1.  **Data Objects Updated:**
    *   `src/Data/Billing/Subscription.php`: Renamed `auto_renew` to `is_auto_renewed`.
    *   `src/Data/Dns/NameRecord.php`: Renamed `disabled` to `is_disabled`.
    *   `src/Data/Vps/Firewall.php`: Renamed `synced` to `is_synced`.
2.  **New Domain Availability Feature:**
    *   Added `src/Data/Domain/Availability.php` data object.
    *   Added `src/Resources/Domain/Availability.php` Resource class.
    *   Updated `src/Facades/DomainFacade.php` to include the `availability()` method.
3.  **Tests Updated/Added:**
    *   Updated tests for `Subscription`, `NameRecord` (via `ZoneTest` and `SnapshotTest`), and `Firewall` to reflect property name changes.
    *   Added `tests/Unit/Resources/Domain/AvailabilityTest.php`.
    *   Updated `tests/Unit/Facades/DomainFacadeTest.php`.
    *   Added more previous missing tests.
4.  **Test Factory Updated:**
    *   `tests/TestFactory.php`: Updated `firewall`, `subscription`, and `dnsNameRecord` methods to use the new property names (`is_synced`, `is_auto_renewed`, `is_disabled`).
5.  **Documentation Updated:**
    *   `README.md`: Added a new section for "Domains -> Availability" and updated examples for DNS and Billing sections to reflect property name changes.